### PR TITLE
only replaces the first occurrence of Iteration from the path

### DIFF
--- a/TFSProjectMigration/TFSWorkItemMigrationUI.xaml.cs
+++ b/TFSProjectMigration/TFSWorkItemMigrationUI.xaml.cs
@@ -26,6 +26,7 @@ using System.Xml;
 using log4net.Config;
 using log4net;
 using System.Threading;
+using System.Text.RegularExpressions;
 
 namespace TFSProjectMigration
 {
@@ -502,7 +503,8 @@ namespace TFSProjectMigration
 
 		private string CanonicolizeIterationPath(string p)
 		{
-			return p.Trim(new[] {'\\'}).Replace("\\Iteration", "");
+            var regex = new Regex(@"\\Iteration");
+            return regex.Replace(p.Trim(new[] { '\\' }), "", 1);
 		}
 
 		private string CanonicolizeAreaPath(string p)


### PR DESCRIPTION
When the iteration path is in the format `\\ProjectName\\Iteration\\Iteration 1`, only removes the first occurrence of the string `\\Iteration`. Otherwise, the name of the iteration would have been `ProjectName 1` causing error when trying to look up iteration path `ProjectName 1`.
